### PR TITLE
TypeError: Path must be a string. Received undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(options) {
     return {
         name: 'rollup-plugin-bundle-size',
         ongenerate(details, result) {
-            const asset = path.basename(details.dest);
+            const asset = path.basename(details.file);
             const size = maxmin(result.code, result.code, true);
             console.log(`Created bundle ${chalk.cyan(asset)}: ${size.substr(size.indexOf(' → ') + 3)}`);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-bundle-size",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Output the size of your bundle",
   "main": "index.js",
   "author": "Brad Dougherty <brad@vimeo.com>",


### PR DESCRIPTION
The plugin is not working with the newest rollup version. Right now is showing the next error:

    TypeError: Path must be a string. Received undefined
        at assertPath (path.js:28:11)
        at Object.basename (path.js:1376:5)

The solution is pretty simple as is pointed here #2.

Hope it can be useful and you can release a new version of this project because I really like the simplicity of how it was done. 