### PR TITLE
fix missing file path option in newer rollup versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(options) {
     return {
         name: 'rollup-plugin-bundle-size',
         ongenerate(details, result) {
-            const asset = path.basename(details.dest);
+            const asset = path.basename(details.file);
             const size = maxmin(result.code, result.code, true);
             console.log(`Created bundle ${chalk.cyan(asset)}: ${size.substr(size.indexOf(' → ') + 3)}`);
         }


### PR DESCRIPTION
TypeError: Cannot read property 'dest' of undefined
    at Object.ongenerate (rollup-plugin-bundle-size/index.js:12:49)
    at bundle.plugins.forEach.plugin (rollup/dist/rollup.js:18689:16)
    at Array.forEach (<anonymous>)
    at Promise.resolve.then.then.rendered (rollup/dist/rollup.js:18687:22)
    at <anonymous>