### PR TITLE
Include extracted assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const chalk = require('chalk');
 const maxmin = require('maxmin');
 
@@ -6,9 +5,12 @@ module.exports = function() {
     return {
         name: 'rollup-plugin-bundle-size',
         generateBundle(options, bundle) {
-            const asset = path.basename(options.file);
-            const size = maxmin(bundle[asset].code, bundle[asset].code, true);
-            console.log(`Created bundle ${chalk.cyan(asset)}: ${size.substr(size.indexOf(' → ') + 3)}`);
+            const files = Object.values(bundle).filter((file) => file.isEntry || file.isAsset);
+            files.forEach((file) => {
+                const code = file.code || file.source;
+                const size = maxmin(code, code, true);
+                console.log(`Created ${chalk.cyan(file.fileName)}: ${size.substr(size.indexOf(' → ') + 3)}`);
+            });
         }
     };
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@vimeo/eslint-config-player": "^4.0.1",
-    "eslint": "^3.3.1"
+    "eslint": "^3.3.1",
+    "eslint-plugin-ava": "^5.1.1"
   }
 }


### PR DESCRIPTION
IMHO it would be helpful to log extracted assets sizes (e.g. when using plugins like `rollup-plugin-postcss` to extract CSS files) as well. What do you think? If so, should it rather be hidden behind an option?

Before:
![image](https://user-images.githubusercontent.com/654171/76147573-fc76d680-609d-11ea-9751-7979c3907b68.png)

After:
![image](https://user-images.githubusercontent.com/654171/76147565-ec5ef700-609d-11ea-9128-a74626cb5b00.png)
