### PR TITLE
Add sample output to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 > A rollup plugin to show the size of the generated bundle(s).
 
+## Sample Output
+
+```bash
+$ rollup -c
+src/project.js → dist/project.bundle.js...
+Created bundle project.bundle.js: 52.53 kB → 18.29 kB (gzip)
+created dist/project.bundle.js in 3.5s
+```
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
I would have found sample output helpful when comparing various rollup bundle size plugins. This adds sample output to the Readme, so that developers can evaluate how this project addresses their size reporting needs without having to install+configure+run to see what the output looks like.