### PR TITLE
Run plugin on `bundle` if `options.file` is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,11 @@ module.exports = function() {
     return {
         name: 'rollup-plugin-bundle-size',
         generateBundle(options, bundle) {
-            const asset = path.basename(options.file);
-            const size = maxmin(bundle[asset].code, bundle[asset].code, true);
-            console.log(`Created bundle ${chalk.cyan(asset)}: ${size.substr(size.indexOf(' → ') + 3)}`);
+            const assets = options.file ? [path.basename(options.file)] : Object.keys(bundle);
+            for (const asset of assets) {
+                const size = maxmin(bundle[asset].code, bundle[asset].code, true);
+                console.log(`Created bundle ${chalk.cyan(asset)}: ${size.substr(size.indexOf(' → ') + 3)}`);
+            }
         }
     };
 };


### PR DESCRIPTION
`rollup-plugin-bundle-size` breaks when bundling multiple code-split entry points (see output below).

```bash
npm run build

> @manzt/zarr-lite@0.0.8 build /Users/fm813/github/manzt/zarr-lite
> rollup -c

loaded rollup.config.js with warnings
(!) Unused external imports
default imported from external module 'path' but never used
default imported from external module 'chalk' but never used
default imported from external module 'maxmin' but never used

src/index.js, src/indexing.js, src/httpStore.js → dist...
[!] (plugin rollup-plugin-bundle-size) TypeError: The "path" argument must be of type string. Received undefined
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:124:11)
    at Object.basename (path.js:1156:5)
    at Object.generateBundle (/Users/fm813/github/manzt/zarr-lite/node_modules/rollup-plugin-bundle-size/index.js:9:32)
    at /Users/fm813/github/manzt/zarr-lite/node_modules/rollup/dist/shared/rollup.js:18757:25
    at processTicksAndRejections (internal/process/task_queues.js:93:5)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @manzt/zarr-lite@0.0.8 build: `rollup -c`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @manzt/zarr-lite@0.0.8 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/fm813/.npm/_logs/2020-12-09T16_35_26_761Z-debug.log
```

In this context `options.file` is `undefined`. This PR checks if `options.file` is present and if so will output the same as before. But if not, it will iterate through the bundle keys. Feel free to close this PR if it is not of interest.